### PR TITLE
updated LUVi and LIT version for windows check issue

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 echo off
 
-set LUVI_VERSION=v2.9.3-sigar
-set LIT_VERSION=3.7.3
+set LUVI_VERSION=v2.7.6-2-sigar
+set LIT_VERSION=3.1.0
 set RMA_VERSION=master
 
 set LIT_URL="https://lit.luvit.io/packages/luvit/lit/v%LIT_VERSION%.zip"


### PR DESCRIPTION
We got a query from customer that windows perf_os check are not working. We identified later that it is with all windows checks and it is because of some LIT version update and also related with windows TLS. So we rolled back to a latest version combination on which these checks are working fine.